### PR TITLE
Add optional parameter `queryParams` to TweetQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ const queue = new TweetQueue(this, 'TweetStream', {
   query: '#awscdk',
 
   // optional properties
+  queryParams: {}           // optional: additional query parameters to pass to Twitter's search endpoint
   intervalMin: 60,          // optional: polling interval in minutes
   retentionPeriodSec: 60,   // optional: queue retention period
   visibilityTimeoutSec: 60, // optional: queue visilibity timeout

--- a/packages/cdk-tweet-queue-poller/lib/index.ts
+++ b/packages/cdk-tweet-queue-poller/lib/index.ts
@@ -1,5 +1,5 @@
 const Twitter = require('twitter');
-import { SecretsManager, SQS, DynamoDB } from 'aws-sdk';
+import { SecretsManager, SQS } from 'aws-sdk';
 import { CheckpointTable } from './checkpoint';
 import { getEnv } from './util';
 

--- a/packages/cdk-tweet-queue-poller/lib/util.ts
+++ b/packages/cdk-tweet-queue-poller/lib/util.ts
@@ -1,9 +1,42 @@
+export class MissingEnvironmentVariableError extends Error {
+  constructor(key: string) {
+    super(`Missing environment variable ${key}`)
+  }
+}
+
+export class InvalidEnvironmentVariableError extends Error {
+  value: string;
+
+  constructor(error: Error, value: string) {
+    super(`Unparseable environment variable value: ${error.message || error}`)
+    this.value = value
+  }
+}
 
 export function getEnv(key: string): string {
   const value = process.env[key];
   if (!value) {
-    throw new Error(`Missing environment variable ${key}`);
+    throw new MissingEnvironmentVariableError(key);
   }
 
   return value;
+}
+
+export interface Json {
+  [x: string]: string | number | boolean | Date | Json | JsonArray;
+}
+export interface JsonArray extends Array<string | number | boolean | Date | Json | JsonArray> { }
+
+export function getJSONEnv<T>(key: string): T {
+  const unparsed = getEnv(key);
+
+  try {
+    return JSON.parse(unparsed);
+  } catch (err) {
+    if (err.name === 'SyntaxError') {
+      throw new InvalidEnvironmentVariableError(err, unparsed)
+    }
+
+    throw err
+  }
 }

--- a/packages/cdk-tweet-queue/lib/tweet-queue.ts
+++ b/packages/cdk-tweet-queue/lib/tweet-queue.ts
@@ -29,7 +29,7 @@ export interface TweetQueueProps {
    * See: https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets
    */
   readonly queryParams?: {
-    [x: string]: string | number | boolean
+    [x: string]: any
   };
 
   /**

--- a/packages/cdk-tweet-queue/lib/tweet-queue.ts
+++ b/packages/cdk-tweet-queue/lib/tweet-queue.ts
@@ -25,6 +25,14 @@ export interface TweetQueueProps {
   readonly query: string;
 
   /**
+   * Extra twitter search parameters.
+   * See: https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets
+   */
+  readonly queryParams?: {
+    [x: string]: string | number | boolean
+  };
+
+  /**
    * Polling interval in minutes.
    * Set to 0 to disable polling.
    * @default 1min
@@ -66,6 +74,7 @@ export class TweetQueue extends sqs.Queue {
       environment: {
         CREDENTIALS_SECRET: props.secretArn,
         TWITTER_QUERY: props.query,
+        TWITTER_QUERY_PARAMS: props.queryParams && JSON.stringify(props.queryParams),
         QUEUE_URL: this.queueUrl,
         CHECKPOINT_TABLE_NAME: table.tableName,
         CHECKPOINT_TABLE_KEY_NAME: keyName

--- a/packages/cdk-tweet-queue/lib/tweet-queue.ts
+++ b/packages/cdk-tweet-queue/lib/tweet-queue.ts
@@ -74,7 +74,7 @@ export class TweetQueue extends sqs.Queue {
       environment: {
         CREDENTIALS_SECRET: props.secretArn,
         TWITTER_QUERY: props.query,
-        TWITTER_QUERY_PARAMS: props.queryParams && JSON.stringify(props.queryParams),
+        TWITTER_QUERY_PARAMS: props.queryParams != null ? JSON.stringify(props.queryParams) : undefined,
         QUEUE_URL: this.queueUrl,
         CHECKPOINT_TABLE_NAME: table.tableName,
         CHECKPOINT_TABLE_KEY_NAME: keyName


### PR DESCRIPTION
*Issue #, if available:*

Fixes #4 

*Description of changes:*

Adds a new optional parameter `queryParams` to `TweetQueue`, allowing the user to pass a set of parameters that will be passed to Twitter's search API. The parameters will not replace existing parameters, such as `c` and `count`.

I was not able to get the tests to run locally. Not sure what I'm doing wrong, but jest isn't finding any tests anywhere. I'm hoping CI is set up to run on PRs, or maybe you could try running it to see that everything works as it should.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
