### PR TITLE
fix(cdk-tweet-queue): update repository url

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -6,7 +6,7 @@ const project = new cdk.JsiiProject({
   description: 'Defines an SQS queue with tweet stream from a search',
   author: 'Elad Ben-Israel',
   authorAddress: 'elad.benisrael@gmail.com',
-  repositoryUrl: 'https://github.com/eladb/cdk-tweet-queue',
+  repositoryUrl: 'https://github.com/cdklabs/cdk-tweet-queue',
   releaseToNpm: true,
   publishToNuget: {
     dotNetNamespace: 'Cdklabs.CdkTweetQueue',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Defines an SQS queue with tweet stream from a search",
   "repository": {
     "type": "git",
-    "url": "https://github.com/eladb/cdk-tweet-queue"
+    "url": "https://github.com/cdklabs/cdk-tweet-queue"
   },
   "scripts": {
     "build": "npx projen build",


### PR DESCRIPTION
Fixes npm publish issue `Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/eladb/cdk-tweet-queue.git", expected to match "https://github.com/cdklabs/cdk-tweet-queue" from provenance`